### PR TITLE
add babel-preset-react-native package to prevent install errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "ava": "^0.16.0",
     "babel-eslint": "^7.0.0",
     "babel-preset-es2015": "^6.16.0",
+    "babel-preset-react-native": "^1.9.0",
     "enzyme": "^2.4.1",
     "esdoc": "^0.4.6",
     "esdoc-es7-plugin": "0.0.3",


### PR DESCRIPTION
Package Install Babel-Preset-React-Native for ES6 Compatibility 
